### PR TITLE
修复stdio输出导致客户端json解析错误的问题

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ async function runSSEServer() {
 async function runServer() {
     const transport = new StdioServerTransport();
     await server.connect(transport);
-    console.log("TongXiao MCP Server running on stdio");
+    console.error("TongXiao MCP Server running on stdio");
 }
 
 


### PR DESCRIPTION
console.log会将字符串通过stdout输出，导致连接服务的时候解析错误，遵循示例项目的做法，将提示信息用stderr输出